### PR TITLE
Fix Arabic company name spelling in hero title

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,12 +71,12 @@ export default function AIHeroPage() {
                 {/* Blue Shadow Layer */}
                 <div className="absolute inset-0 transform translate-x-2 translate-y-2">
                   <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-blue-400/20 to-cyan-400/20 bg-clip-text text-transparent blur-sm">
-                    وكيل الذكاء الاصطناعي من رؤيا كابيتا
+                    وكيل الذكاء الاصطناعي من رؤيا كابيتال
                   </h1>
                 </div>
                 {/* Main Title */}
                 <h1 className="relative text-4xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-white via-gray-100 to-gray-200 bg-clip-text text-transparent">
-                  وكيل الذكاء الاصطناعي من رؤيا كابيتا
+                  وكيل الذكاء الاصطناعي من رؤيا كابيتال
                 </h1>
               </div>
 


### PR DESCRIPTION
Updates the Arabic company name in the hero page title from "رؤيا كابيتا" to "رؤيا كابيتال".

Changes made:
- Fixed spelling in the blue shadow layer title
- Fixed spelling in the main title element

Both instances of the company name in the hero section now use the correct Arabic spelling.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3ac22f98fbc44ad1ad7237d4f90aa23d/spark-hub)

👀 [Preview Link](https://3ac22f98fbc44ad1ad7237d4f90aa23d-spark-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3ac22f98fbc44ad1ad7237d4f90aa23d</projectId>-->
<!--<branchName>spark-hub</branchName>-->